### PR TITLE
Added foreach in support, and removed C++17 experimental

### DIFF
--- a/langs/StdLibs/one.hpp
+++ b/langs/StdLibs/one.hpp
@@ -4,10 +4,9 @@
 #include <map>
 #include <iostream>
 #include <regex>
-#include <experimental/any>
+#include <any>
 
 using namespace std;
-using namespace std::experimental;
 
 template <typename T>
 using sp = shared_ptr<T>;

--- a/langs/cpp.yaml
+++ b/langs/cpp.yaml
@@ -341,7 +341,7 @@ expressions:
     {{/for}}
   foreach: |-
     for (auto it = {{gen(expr.items)}}->begin(); it != {{gen(expr.items)}}->end(); ++it) {
-        auto {{expr.itemVariable.outName}} = *it;
+        auto {{expr.itemVariable.outName}} = it->first;
         {{genBody(expr.body)}}
     }
   for: |-

--- a/src/Parsers/TypeScriptParser2.ts
+++ b/src/Parsers/TypeScriptParser2.ts
@@ -195,7 +195,7 @@ export class TypeScriptParser2 implements IParser {
             this.reader.expectToken("(");
             const varDeclMod = this.reader.readAnyOf(["const", "let", "var"]);
             const itemVarName = this.reader.expectIdentifier();
-            if (this.reader.readToken("of")) {
+            if (this.reader.readToken("of") || this.reader.readToken("in")) {
                 const foreachStmt = statement = <ast.ForeachStatement> { 
                     stmtType: ast.StatementType.Foreach,
                     itemVariable: <ast.VariableBase> { name: itemVarName }


### PR DESCRIPTION
When compiling the generated C++ code using g++, be sure to set -std=c++17.

Before this I wasn't able to do:

        for (let key in mapObj)
        {
            console.log (`Key: ${key}`);
        }